### PR TITLE
Added ability to disable comments with front matter "disable_comments"

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -19,7 +19,7 @@
 
 </main>
 
-{{ if .Site.DisqusShortname }}
+{{ if and .Site.DisqusShortname (not .Params.disable_comments)}}
   {{ template "_internal/disqus.html" . }}
 {{ end }}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -19,7 +19,7 @@
 
 </main>
 
-{{ if and .Site.DisqusShortname (not .Params.disable_comments)}}
+{{ if and .Site.DisqusShortname (not .Params.disableComments) }}
   {{ template "_internal/disqus.html" . }}
 {{ end }}
 


### PR DESCRIPTION
With this change, users can add "disable_comments = true" in a post's front matter to disable Disqus loading for that page. Useful for "About" and other similar pages.