### PR TITLE
Fix invalid <head>

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,16 +1,10 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
-
     <head>
-
-        <title>{{ .Title }}</title>
-
-        {{ partial "css" . }} {{ partial "js" . }} {{ .Hugo.Generator }}
-
         <meta charset="utf-8">
-
         <meta name="viewport" content="width=device-width, initial-scale=1">
-
+        <title>{{ .Title }}</title>
+        {{ partial "css" . }} {{ partial "js" . }} {{ .Hugo.Generator }}
     </head>
 
     <body>


### PR DESCRIPTION
Rejigger <head></head> order.

The `charset` meta element must be in the [first 1024 bytes](https://www.w3.org/International/questions/qa-html-encoding-declarations#quickanswer) in order to validate.