### PR TITLE
fixed disqus template ref

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -21,7 +21,7 @@
 
         <h4 class="page-header">Comments</h4>
 
-        {{ template "_internal/disqus" . }}
+        {{ template "_internal/disqus.html" . }}
 
     {{ end }}
 


### PR DESCRIPTION
Hi,
After you fixed the Disqus width issue, it looks like the ".html" was removed from the disqus template reference. This caused an error upon building a site. Adding the .html back fixed the issue. 
Thanks!