### PR TITLE
Improved the responsiveness of img.

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -88,3 +88,7 @@ a:hover {
 footer {
     border-bottom: var(--border-width) solid var(--accent);
 }
+
+img {
+    max-width: 100%;
+}


### PR DESCRIPTION
Without this tweak, when the viewport is smaller than the image, the image overflows the page.
With this commit it will be resized to fit the available width.

I'm not a css expert, but adding this rule makes my website much more usable from mobile. For now I added this extra rule in an additional css, but I think it might be a sensible default