### PR TITLE
Added quotes to font-family property in css.html to enable loading of…

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,7 +1,7 @@
 <style>
 
     html body {
-        font-family: {{ .Site.Params.font }}, sans-serif;
+        font-family: '{{ .Site.Params.font }}', sans-serif;
         background-color: {{ .Site.Params.backgroundColor | default "white" }};
     }
 


### PR DESCRIPTION
… fonts with multiple spaces in the name

I had trouble loading the Google Font [Press Start 2P](https://fonts.google.com/specimen/Press+Start+2P). Adding single quotes solved the issue.