### PR TITLE
Add anchor link to tag

### DIFF
--- a/layouts/partials/list-item.html
+++ b/layouts/partials/list-item.html
@@ -18,6 +18,10 @@
 
     <h4><a href="{{ .Scratch.Get "link" }}">{{ .Title }}</a></h4>
     <h5>{{ $.Scratch.Get "subtitle" }}</h5>
-    {{ range .Params.tags }} <kbd class="item-tag">{{ . }}</kbd> {{ end }}
+    {{ range .Params.tags }}
+    <a href="{{ $.Site.BaseURL }}tags/{{ . }}">
+        <kbd class="item-tag">{{ . }}</kbd>
+    </a>
+    {{ end }}
 
 </div>


### PR DESCRIPTION
This enables users to jump to a list of posts that are related to a tag by clicking the tag.