### PR TITLE
make mathjax optional

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,10 +24,12 @@
         {{ end }}
     </head>
 
+    {{ if .Site.Params.MathJax | default true }}
     <!-- adds MathJax support -->
     <script type="text/javascript" async
       src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
-  </script>
+    </script>
+    {{ end }}
 
     <body>
         {{ partial "body-open" . }}


### PR DESCRIPTION
add option to disable mathjax. defaults to enabled for backward compatibility.