### PR TITLE
Night mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.vscode
+.Rproj.user

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Calin Tataru
+Copyright (c) 2017 Nate Day
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ After installation, take a look at the `exampleSite` folder inside `themes/minim
 To get started, copy the `config.toml` file inside `exampleSite` to the root of your Hugo site:
 
 ```
-$ cp themes/minimal/exampleSite/config.toml .
+$ cp themes/min_night/exampleSite/config.toml .
 ```
 
 This file is the centerpiece for easy theme customizations. Some noteable features are described next.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A sleek toggleable night-mode theme for [Hugo](https://gohugo.io). Built on top 
 
 - A night-mode toggle, for eye easy reading
 - A tags/categories list page template from [Xmin](https://github.com/yihui/hugo-xmin)
-- Updated tag/category labels to hyperlinks back to list of sames
+- Updated tag labels to hyperlinks
 - Different list templates for posts and projects
 
 A live demo is available [here](https://natedayta.com).
@@ -84,3 +84,7 @@ The style and languages should be written in hyphen-separated lowercase, for exa
     highlightStyle = "solarized-dark"
     highlightLanguages = ["r", "go"]
 ```
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # MinNight
 
-A sleek toggleable night-mode theme for [Hugo](https://gohugo.io). Built on top on the great [Minimal](https://github.com/calintat/minimal) theme. With all of the great Minimal implementations, like custom accent colors, FontAwesome
+A sleek toggleable night-mode theme for [Hugo](https://gohugo.io). Built on top on the great [Minimal](https://github.com/calintat/minimal) theme. Keeps all of the great Minimal stuff, like custom accent color, Google Fonts, FontAwesome menu icons, and layers on:
 
-- A night-mode toggle!!!
+- A night-mode toggle, for eye easy reading
 - A tags/categories list page template from [Xmin](https://github.com/yihui/hugo-xmin)
-- Seperate list templates for posts and projects
-- All tags/categories are links 
+- Updated tag/category labels to hyperlinks back to list of sames
+- Different list templates for posts and projects
 
 A live demo is available [here](https://natedayta.com).
 
@@ -27,7 +27,7 @@ Now you can get updates to Minimal in the future by updating the submodule:
 $ git submodule update --remote themes/min_night
 ```
 
-I use this theme via the `R` pacakge `blogdown`, you can do the same with.
+I use this theme via the `R` pacakge `blogdown`, you can do the same in R.
 
 ```
 library(blogdown)
@@ -74,7 +74,7 @@ The theme uses [Google Fonts](https://fonts.google.com) to load its font. To cha
 
 ### Syntax highlighting
 
-The theme supports syntax highlighting thanks to [highlight.js](https://highlightjs.org). You can change the color sheme via the `highlightStyle` param. Checkout out the options [here](https://highlightjs.org/static/demo/), make sure your main languages render well. For best results with dark-mode, I reccommend choosing a light background style that matches your `accent` color. You control the languages that are highlighted with the `highlightLanguages` param.
+The theme supports syntax highlighting thanks to [highlight.js](https://highlightjs.org). You can change the color scheme via the `highlightStyle` param. Checkout out the options [here](https://highlightjs.org/static/demo/), make sure your main languages render well. For best results with dark-mode, I reccommend choosing a light background style that matches your `accent` color. You control the languages that are highlighted with the `highlightLanguages` param.
 
 The style and languages should be written in hyphen-separated lowercase, for example:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # Minimal2
 
-Personal blog theme powered by [Hugo](https://gohugo.io).
-A live demo is available [here](https://themungler.com).
+A personal blog theme powered by [Hugo](https://gohugo.io), built on top on the great [Minimal](https://github.com/calintat/minimal) theme. The notable additions include:
+
+- A night-mode toggle
+- A larger more defined footer
+- A tags/categories partial template
+- All tags are links too
+- Seperate list templates for posts and projects
+
+A live demo is available [here](https://natedayta.com).
 
 ## Installation
 
@@ -23,7 +30,7 @@ $ git submodule update --remote themes/minimal
 
 ## Configuration
 
-After installation, take a look at the `exampleSite` folder inside `themes/minimal`.
+After installation, take a look at the `exampleSite` folder inside `themes/minimal2`.
 
 To get started, copy the `config.toml` file inside `exampleSite` to the root of your Hugo site:
 
@@ -51,8 +58,9 @@ For best results, I recommend you use a dark accent colour with a light backgrou
 [params]
     accent = "red"
     showBorder = true
-    backgroundColor = "white"
+    backgroundColor = "#f5f5f5"
 ```
+You can use hex codes or color names ("red"), I reccomend using hex codes for more specific color assignments.
 
 ### Fonts
 
@@ -81,5 +89,5 @@ Please note the style and languages should be written in hyphen-separated lowerc
 [params]
     highlight = true
     highlightStyle = "solarized-dark"
-    highlightLanguages = ["go", "haskell", "kotlin", "scala", "swift"]
+    highlightLanguages = ["R"]
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-# Minimal2
+# MinNight
 
-A personal blog theme powered by [Hugo](https://gohugo.io), built on top on the great [Minimal](https://github.com/calintat/minimal) theme. The notable additions include:
+A sleek toggleable night-mode theme for [Hugo](https://gohugo.io). Built on top on the great [Minimal](https://github.com/calintat/minimal) theme. With all of the great Minimal implementations, like custom accent colors, FontAwesome
 
-- A night-mode toggle
-- A larger more defined footer
-- A tags/categories partial template
-- All tags are links too
+- A night-mode toggle!!!
+- A tags/categories list page template from [Xmin](https://github.com/yihui/hugo-xmin)
 - Seperate list templates for posts and projects
+- All tags/categories are links 
 
 A live demo is available [here](https://natedayta.com).
 
@@ -17,7 +16,7 @@ You can install the theme either as a clone or submodule.
 I recommend the latter. From the root of your Hugo site, type the following:
 
 ```
-$ git submodule add https://github.com/calintat/minimal.git themes/minimal
+$ git submodule add https://github.com/nathancday/min_night themes/min_night
 $ git submodule init
 $ git submodule update
 ```
@@ -25,7 +24,14 @@ $ git submodule update
 Now you can get updates to Minimal in the future by updating the submodule:
 
 ```
-$ git submodule update --remote themes/minimal
+$ git submodule update --remote themes/min_night
+```
+
+I use this theme via the `R` pacakge `blogdown`, you can do the same with.
+
+```
+library(blogdown)
+new_site(theme = "nathancday/min_night")
 ```
 
 ## Configuration
@@ -38,29 +44,24 @@ To get started, copy the `config.toml` file inside `exampleSite` to the root of 
 $ cp themes/minimal/exampleSite/config.toml .
 ```
 
-Now edit this file and add your own information. Note that some fields can be ommited.
-
-I recommend you use the theme's archetypes so now delete your site's `archetypes/default.md`.
+This file is the centerpiece for easy theme customizations. Some noteable features are described next.
 
 ## Features
 
-You can tweak the look of the theme to suit your needs in a number of ways:
+- The accent colour can be changed by using the `accent` field in `config.toml`. This is the color that will be used as the background of your site in dark-mode. Dark colors work best.
 
-- The accent colour can be changed by using the `accent` field in `config.toml`.
+- You can also change the background color of the main page by using `backgroundColor`. The navbar and footer are always light and dark in the their respective modes.
 
-- You can also change the background colour by using `backgroundColor`.
+- Add colored 5px borders at the top and bottom of pages by setting `showBorder` to `true`. Even if this is set to `false` the `accent` color will still be used for the main page background in dark-mode.
 
-- Add colored 5px borders at the top and bottom of pages by setting `showBorder` to `true`.
-
-For best results, I recommend you use a dark accent colour with a light background, for example:
-
+Example:
 ```toml
 [params]
     accent = "red"
     showBorder = true
     backgroundColor = "#f5f5f5"
 ```
-You can use hex codes or color names ("red"), I reccomend using hex codes for more specific color assignments.
+You can use either hex codes or color names ("red"), I reccomend using hex codes for more specific color assignments.
 
 ### Fonts
 
@@ -73,21 +74,13 @@ The theme uses [Google Fonts](https://fonts.google.com) to load its font. To cha
 
 ### Syntax highlighting
 
-The theme supports syntax highlighting thanks to [highlight.js](https://highlightjs.org).
+The theme supports syntax highlighting thanks to [highlight.js](https://highlightjs.org). You can change the color sheme via the `highlightStyle` param. Checkout out the options [here](https://highlightjs.org/static/demo/), make sure your main languages render well. For best results with dark-mode, I reccommend choosing a light background style that matches your `accent` color. You control the languages that are highlighted with the `highlightLanguages` param.
 
-It's disabled by default, so you have to enable it by setting `highlight` to `true` in your config.
-
-You can change the style used for the highlighting by using the `highlightStyle` field.
-
-Only the "common" languages will be loaded by default. To load more, use `highlightLanguages`.
-
-A list of all the available styles and languages can be found [here](https://highlightjs.org/static/demo/).
-
-Please note the style and languages should be written in hyphen-separated lowercase, for example:
+The style and languages should be written in hyphen-separated lowercase, for example:
 
 ```toml
 [params]
     highlight = true
     highlightStyle = "solarized-dark"
-    highlightLanguages = ["R"]
+    highlightLanguages = ["r", "go"]
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Minimal
+# Minimal2
 
 Personal blog theme powered by [Hugo](https://gohugo.io).
-A live demo is available [here](https://themes.gohugo.io/theme/minimal/).
+A live demo is available [here](https://themungler.com).
 
 ## Installation
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,9 +1,9 @@
 baseURL = "/"
 languageCode = "en-us"
-title = "NateDay-ta"
-description = "R focused data docs"
+title = "Min Night"
+description = "A personal blog"
 theme = "minimal"
-disqusShortname = ""#"nateday-me" # delete this to disable disqus comments
+disqusShortname = ""
 googleAnalytics = ""
 ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_files/", "_cache$"]
 
@@ -11,15 +11,15 @@ ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_files/", "_cache$"]
     post = "/:year/:month/:day/:slug/"
 
 [params]
-    author = "Nate Day"
-    description = "R focused data docs"
-    githubUsername = "NathanCDay"
-    accent = "#006264"
+    author = ""
+    description = "A personal blog"
+    githubUsername = ""
+    accent = "maroon" # dark colors do best
     showBorder = true
     backgroundColor = "#f5f5f5"
     font = "Raleway" # should match the name on Google Fonts!
     highlight = true
-    highlightStyle = "atelier-seaside-light"
+    highlightStyle = "atelier-heath-light"
     highlightLanguages = ["R"]
 
 [[menu.main]]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,21 +1,26 @@
-baseURL = "http://example.com/"
+baseURL = "/"
 languageCode = "en-us"
-title = "Minimal"
+title = "NateDay-ta"
+description = "R focused data docs"
 theme = "minimal"
-disqusShortname = "username" # delete this to disable disqus comments
+disqusShortname = ""#"nateday-me" # delete this to disable disqus comments
 googleAnalytics = ""
+ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_files$", "_cache$"]
+
+[permalinks]
+    post = "/:year/:month/:day/:slug/"
 
 [params]
-    author = "Calin Tataru"
-    description = "Personal blog theme powered by Hugo"
-    githubUsername = "#"
-    accent = "red"
+    author = "Nate Day"
+    description = "R focused data docs"
+    githubUsername = "NathanCDay"
+    accent = "darkblue"
     showBorder = true
-    backgroundColor = "white"
+    backgroundColor = "#f5f5f5"
     font = "Raleway" # should match the name on Google Fonts!
     highlight = true
-    highlightStyle = "solarized-dark"
-    highlightLanguages = ["go", "haskell", "kotlin", "scala", "swift"]
+    highlightStyle = "tomorrow-night-blue"
+    highlightLanguages = ["R"]
 
 [[menu.main]]
     url = "/"
@@ -31,32 +36,37 @@ googleAnalytics = ""
     url = "/project/"
     name = "Projects"
     weight = 3
+    
+[[menu.main]]
+    url = "/tags/"
+    name = "Tags"
+    weight = 4
 
 # Social icons to be shown on the right-hand side of the navigation bar
 # The "name" field should match the name of the icon to be used
 # The list of available icons can be found at http://fontawesome.io/icons/
 
 [[menu.icon]]
-    url = "mailto:me@example.com"
+    url = "mailto:nathancday@gmail.com"
     name = "envelope-o"
     weight = 1
 
 [[menu.icon]]
-    url = "https://github.com/username/"
+    url = "https://github.com/NathanCDay"
     name = "github"
     weight = 2
 
 [[menu.icon]]
-    url = "https://twitter.com/username/"
+    url = "https://twitter.com/offallday/"
     name = "twitter"
     weight = 3
 
 [[menu.icon]]
-    url = "https://www.linkedin.com/in/username/"
+    url = "https://www.linkedin.com/in/nathan-day-59b48435/"
     name = "linkedin"
     weight = 4
 
 [[menu.icon]]
-    url = "https://www.stackoverflow.com/username/"
+    url = "https://www.stackoverflow.com/users/5878751/nate"
     name = "stack-overflow"
     weight = 5

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -7,7 +7,7 @@ googleAnalytics = ""
 
 [params]
     author = "Calin Tataru"
-    description = "Personal blog theme powered by Hugo"
+    description = "Personal blog theme with night-mode powered by Hugo"
     githubUsername = "#"
     accent = "maroon"
     showBorder = true

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,8 +1,8 @@
 baseURL = "/"
 languageCode = "en-us"
-title = "MinNight"
+title = "Min_Night"
 description = "A sleek dark-mode toggle-able Hugo theme"
-theme = "MinNight"
+theme = "min_night"
 disqusShortname = ""
 googleAnalytics = ""
 ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "public/"]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,26 +1,21 @@
 baseURL = "/"
 languageCode = "en-us"
-title = "Min_Night"
-description = "A sleek dark-mode toggle-able Hugo theme"
-theme = "min_night"
-disqusShortname = ""
+title = "Minimal"
+theme = "minimal"
+disqusShortname = "username" # delete this to disable disqus comments
 googleAnalytics = ""
-ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "public/"]
-
-[permalinks]
-    post = "/:year/:month/:day/:slug/"
 
 [params]
-    author = ""
-    description = "A sleek dark-mode toggle-able Hugo theme"
-    githubUsername = "nathancday"
-    accent = "maroon" # dark colors do best
+    author = "Calin Tataru"
+    description = "Personal blog theme powered by Hugo"
+    githubUsername = "#"
+    accent = "maroon"
     showBorder = true
     backgroundColor = "#f5f5f5"
     font = "Raleway" # should match the name on Google Fonts!
     highlight = true
-    highlightStyle = "atelier-heath-light" # make this match accent
-    highlightLanguages = ["r", "go"]
+    highlightStyle = "atelier-heath-light" # make this complement accent color!
+    highlightLanguages = ["go", "haskell", "kotlin", "scala", "swift", "r"]
 
 # adjust these as you see fit
 [[menu.main]]
@@ -48,26 +43,26 @@ ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "public/"]
 # The list of available icons can be found at http://fontawesome.io/icons/
 
 [[menu.icon]]
-    url = "mailto:nathancday@gmail.com"
+    url = "mailto:me@example.com"
     name = "envelope-o"
     weight = 1
 
 [[menu.icon]]
-    url = "https://github.com/NathanCDay"
+    url = "https://github.com/username/"
     name = "github"
     weight = 2
 
 [[menu.icon]]
-    url = "https://twitter.com/offallday/"
+    url = "https://twitter.com/username/"
     name = "twitter"
     weight = 3
 
 [[menu.icon]]
-    url = "https://www.linkedin.com/in/nathan-day-59b48435/"
+    url = "https://www.linkedin.com/in/username/"
     name = "linkedin"
     weight = 4
 
 [[menu.icon]]
-    url = "https://www.stackoverflow.com/users/5878751/nate"
+    url = "https://www.stackoverflow.com/username/"
     name = "stack-overflow"
     weight = 5

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,7 +5,7 @@ description = "R focused data docs"
 theme = "minimal"
 disqusShortname = ""#"nateday-me" # delete this to disable disqus comments
 googleAnalytics = ""
-ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_files$", "_cache$"]
+ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_files/", "_cache$"]
 
 [permalinks]
     post = "/:year/:month/:day/:slug/"
@@ -14,12 +14,12 @@ ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_files$", "_cache$"]
     author = "Nate Day"
     description = "R focused data docs"
     githubUsername = "NathanCDay"
-    accent = "darkblue"
+    accent = "#006264"
     showBorder = true
     backgroundColor = "#f5f5f5"
     font = "Raleway" # should match the name on Google Fonts!
     highlight = true
-    highlightStyle = "tomorrow-night-blue"
+    highlightStyle = "atelier-seaside-light"
     highlightLanguages = ["R"]
 
 [[menu.main]]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,27 +1,28 @@
 baseURL = "/"
 languageCode = "en-us"
-title = "Min Night"
-description = "A personal blog"
-theme = "minimal"
+title = "MinNight"
+description = "A sleek dark-mode toggle-able Hugo theme"
+theme = "MinNight"
 disqusShortname = ""
 googleAnalytics = ""
-ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_files/", "_cache$"]
+ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "public/"]
 
 [permalinks]
     post = "/:year/:month/:day/:slug/"
 
 [params]
     author = ""
-    description = "A personal blog"
-    githubUsername = ""
+    description = "A sleek dark-mode toggle-able Hugo theme"
+    githubUsername = "nathancday"
     accent = "maroon" # dark colors do best
     showBorder = true
     backgroundColor = "#f5f5f5"
     font = "Raleway" # should match the name on Google Fonts!
     highlight = true
-    highlightStyle = "atelier-heath-light"
-    highlightLanguages = ["R"]
+    highlightStyle = "atelier-heath-light" # make this match accent
+    highlightLanguages = ["r", "go"]
 
+# adjust these as you see fit
 [[menu.main]]
     url = "/"
     name = "Home"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -4,10 +4,10 @@
     <h2>{{ .Title }}</h2>
 
     {{ range (.Paginator 10).Pages }}
-        {{ if eq "Projects" $.Title }}
-            {{ partial "list-item-project" . }}
+        {{ if eq "Posts" $.Title }}
+           {{partial "list-item-post.html" .}}
         {{else}}
-            {{partial "list-item-post.html" .}}
+            {{ partial "list-item-project" . }}
         {{end}}
     {{end}}
     

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,16 +1,16 @@
 {{ partial "header" . }}
 
 <main>
-
     <h2>{{ .Title }}</h2>
 
-    {{ range (.Paginator 5).Pages }} {{ partial "list-item" . }}
-        {{ if eq "Posts" $.Title }}
-            {{ .ReadingTime}} minutes
+    {{ range (.Paginator 10).Pages }}
+        {{ if eq "Projects" $.Title }}
+            {{ partial "list-item-project" . }}
+        {{else}}
+            {{partial "list-item-post.html" .}}
         {{end}}
+    {{end}}
     
-    {{ end }}
-
 </main>
 
 {{ partial "paginator" . }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -4,10 +4,16 @@
 
     <h2>{{ .Title }}</h2>
 
-    {{ range (.Paginator 5).Pages }} {{ partial "list-item" . }} {{ end }}
+    {{ range (.Paginator 5).Pages }} {{ partial "list-item" . }}
+        {{ if eq "Posts" $.Title }}
+            {{ .ReadingTime}} minutes
+        {{end}}
+    
+    {{ end }}
 
 </main>
 
 {{ partial "paginator" . }}
+
 
 {{ partial "footer" . }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,13 +1,23 @@
 {{ partial "header" . }}
 
 <main>
-
-    <h2>{{ .Title }}</h2>
-
-    {{ range (.Paginator 5).Pages }} {{ partial "list-item" . }} {{ end }}
+    
+    <div>
+      <h2>{{ .Title }}</h2>
+    
+      <ul class="terms">
+          {{ range $key, $value := .Data.Terms }}
+          <li>
+            <a href='{{ (print "/" $.Data.Plural "/" $key) | relURL }}'>
+              {{ $key }}
+            </a>
+            ({{ len $value }})
+          </li>
+          {{ end }}
+        </ul>
+    </div>
 
 </main>
-
-{{ partial "paginator" . }}
+  
 
 {{ partial "footer" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,6 +9,7 @@
         <h1>{{ .Site.Title }}</h1>
 
         <h2>{{ markdownify .Site.Params.Description }}</h2>
+
         
     </div>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ partial "header" . }}
 
-<main>
+<main class = "content-box">
 
     <div class="intro">
 
@@ -8,9 +8,14 @@
 
         <h1>{{ .Site.Title }}</h1>
 
-        <h2>{{ markdownify .Site.Params.Description }}</h2>
 
+        </h1>
+
+        <h2>{{ markdownify .Site.Params.Description }}</h2>
+        
+        
     </div>
+    
 
 </main>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,13 +9,10 @@
         <h1>{{ .Site.Title }}</h1>
 
 
-        </h1>
-
         <h2>{{ markdownify .Site.Params.Description }}</h2>
         
         
     </div>
-    
 
 </main>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,6 +7,7 @@
         {{ with .Site.Params.profilePic }} <img class="profile" src="{{ . }}"> {{ end }}
 
         <h1>{{ .Site.Title }}</h1>
+        
 
         <h2>{{ markdownify .Site.Params.Description }}</h2>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,7 +10,6 @@
 
         <h2>{{ markdownify .Site.Params.Description }}</h2>
 
-        
     </div>
 
 </main>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,7 +7,6 @@
         {{ with .Site.Params.profilePic }} <img class="profile" src="{{ . }}"> {{ end }}
 
         <h1>{{ .Site.Title }}</h1>
-        
 
         <h2>{{ markdownify .Site.Params.Description }}</h2>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,9 +8,7 @@
 
         <h1>{{ .Site.Title }}</h1>
 
-
         <h2>{{ markdownify .Site.Params.Description }}</h2>
-        
         
     </div>
 

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -20,6 +20,7 @@
 
 <!-- google fonts -->
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family={{ .Site.Params.font }}">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=VT323">
 
 <!-- highlight.js -->
 {{ if .Site.Params.highlight | default false }} <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/{{ .Site.Params.highlightStyle | default "default" }}.min.css"> {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,7 +7,6 @@
                 <i class="fa fa-creative-commons" aria-hidden="true"></i> Attribution 4.0 International license
                 </a>
             </div>
-
         </footer>
        
     </body>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,6 +8,14 @@
                 </a>
             </div>
         </footer>
+        <!-- Global Site Tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments)};
+          gtag('js', new Date());
+          gtag('config', '{{ .Site.GoogleAnalytics }}');
+        </script>
        
     </body>
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,12 @@
         <footer>
-
-            <p class="copyright text-muted">{{ .Site.Params.copyright | default "&copy; All rights reserved. Powered by [Hugo](https://gohugo.io) and [Minimal](https://github.com/calintat/minimal)" | markdownify }}</p>
+            <div style = "padding:15px;">
+                <p class="copyright text-muted">{{ .Site.Params.copyright | default "&copy; Nate Day . Powered by [Hugo](https://gohugo.io) and [Minimal](https://github.com/calintat/minimal)" | markdownify }}
+                </p>
+                <a rel="license" href="https://creativecommons.org/licenses/by/4.0/"
+                title="Creative Commons Attribution 4.0 International license">
+                <i class="fa fa-creative-commons" aria-hidden="true"></i> Attribution 4.0 International license
+                </a>
+            </div>
 
         </footer>
        

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,6 @@
         <footer>
             <div style = "padding:15px;">
-                <p class="copyright text-muted">{{ .Site.Params.copyright | default "&copy; Nate Day . Powered by [Hugo](https://gohugo.io) and [Minimal](https://github.com/calintat/minimal)" | markdownify }}
+                <p class="copyright text-muted">{{ .Site.Params.copyright | default "&copy; Nate Day . Powered by [Hugo](https://gohugo.io) and [MinNight](https://github.com/nathancday/min_night)" | markdownify }}
                 </p>
                 <a rel="license" href="https://creativecommons.org/licenses/by/4.0/"
                 title="Creative Commons Attribution 4.0 International license">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,11 +1,7 @@
         <footer>
             <div style = "padding:15px;">
-                <p class="copyright text-muted">{{ .Site.Params.copyright | default "&copy; Nate Day . Powered by [Hugo](https://gohugo.io) and [MinNight](https://github.com/nathancday/min_night)" | markdownify }}
+                <p class="copyright text-muted">{{ .Site.Params.copyright | default "&copy; All rights reserved. Powered by [Hugo](https://gohugo.io) and [Minimal](https://github.com/calintat/minimal)" | markdownify }}
                 </p>
-                <a rel="license" href="https://creativecommons.org/licenses/by/4.0/"
-                title="Creative Commons Attribution 4.0 International license">
-                <i class="fa fa-creative-commons" aria-hidden="true"></i> Attribution 4.0 International license
-                </a>
             </div>
         </footer>
         <!-- Global Site Tag (gtag.js) - Google Analytics -->

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -25,6 +25,16 @@
           gtag('config', '{{ .Site.GoogleAnalytics }}');
         </script>
         {{ end }}
+        
+    <!--- Favicons from  --->
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png">
+    <link rel="manifest" href="/images/favicon/manifest.json">
+    <link rel="mask-icon" href="/images/favicon/safari-pinned-tab.svg" color="#006264">
+    <link rel="shortcut icon" href="/images/favicon/favicon.ico">
+    <meta name="msapplication-config" content="/images/favicon/browserconfig.xml">
+    <meta name="theme-color" content="#ffffff">
     </head>
 
     {{ if .Site.Params.MathJax | default true }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -34,7 +34,7 @@
     </script>
     {{ end }}
 
-    <body>
+    <body id = "bigbody">
         {{ partial "body-open" . }}
         <nav class="navbar navbar-default navbar-fixed-top">
 
@@ -67,6 +67,8 @@
                             {{ range sort .Site.Menus.icon }}
                                 <li class="navbar-icon"><a href="{{ .URL }}"><i class="fa fa-{{ .Name }}"></i></a></li>
                             {{ end }}
+                            
+                            {{ partial "toggle"}}
                         </ul>
                     {{ end }}
 

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -33,19 +33,19 @@ $(document).ready(function(){
   var container = $('#bigbody');
   var stat = $('#button-status');
   
-  container.toggleClass(sessionStorage.toggled);
-  stat.bootstrapToggle(sessionStorage.button).change();
+  container.toggleClass(localStorage.toggled);
+  stat.bootstrapToggle(localStorage.button).change();
   
   
   input.on('click', function() {
-      if (sessionStorage.toggled != "-nightmode" ) {
+      if (localStorage.toggled != "-nightmode" ) {
           container.toggleClass("-nightmode", true );
-          sessionStorage.toggled = "-nightmode";
-          sessionStorage.button = "on";
+          localStorage.toggled = "-nightmode";
+          localStorage.button = "on";
        } else {
           container.toggleClass("-nightmode", false );
-          sessionStorage.toggled = "";
-          sessionStorage.button = "off"
+          localStorage.toggled = "";
+          localStorage.button = "off"
        }
   })
 });

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -18,5 +18,38 @@
 <!-- bootstrap -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
+<!-- boostrap toggle tool -->
+<link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">
+<script src="https://gitcdn.github.io/bootstrap-toggle/2.2.2/js/bootstrap-toggle.min.js"></script>
+
 <!-- dismiss expanded navigation bar with click -->
 <script>$(document).on('click', function() { $('.collapse').collapse('hide'); })</script>
+
+<!-- nightmode css changes -->
+<script>
+$(document).ready(function(){
+    
+  var input = $('#night-mode-toggle');
+  var container = $('#bigbody');
+  var stat = $('#button-status');
+  
+  container.toggleClass(sessionStorage.toggled);
+  stat.bootstrapToggle(sessionStorage.button).change();
+  
+  
+  input.on('click', function() {
+      if (sessionStorage.toggled != "-nightmode" ) {
+          container.toggleClass("-nightmode", true );
+          sessionStorage.toggled = "-nightmode";
+          sessionStorage.button = "on";
+       } else {
+          container.toggleClass("-nightmode", false );
+          sessionStorage.toggled = "";
+          sessionStorage.button = "off"
+       }
+  })
+});
+</script>
+
+
+

--- a/layouts/partials/list-item-post.html
+++ b/layouts/partials/list-item-post.html
@@ -21,7 +21,6 @@
     <h4><a href="{{ .Scratch.Get "link" }}">{{ .Title }}</a></h4>
     <h5>{{ $.Scratch.Get "pub_date" }} - {{ $.Scratch.Get "read_time" }} minutes</h5>
     <h5>{{ $.Scratch.Get "subtitle" }}</h5>
-
     {{ range.Params.categories }}
         <a href="{{"/categories/"|relLangURL }}{{.|urlize}}">
         <kbd class="item-cat"> {{ . }} </kbd>

--- a/layouts/partials/list-item-project.html
+++ b/layouts/partials/list-item-project.html
@@ -1,0 +1,36 @@
+<div class="item">
+    
+{{ $.Scratch.Set "link" .RelPermalink }}
+{{ with .Params.repo }}
+{{ $repoHost := default "github" $.Params.repoHost }}
+{{ if eq "github" $repoHost }}
+{{ printf "https://github.com/%s/%s/" $.Site.Params.githubUsername . | $.Scratch.Set "link" }}
+{{ else if eq "gitlab" $repoHost }}
+{{ printf "https://gitlab.com/%s/%s/" $.Site.Params.gitlabUsername . | $.Scratch.Set "link" }}
+{{ else if eq "bitbucket" $repoHost }}
+{{ printf "https://bitbucket.org/%s/%s/" $.Site.Params.bitbucketUsername . | $.Scratch.Set "link" }}
+{{ end }}
+{{ end }}
+{{ with .Params.link }} {{ $.Scratch.Set "link" . }} {{ end }}
+
+{{ .Date.Format (.Site.Params.dateFormat | default "January 2, 2006") | $.Scratch.Set "pub_date" }}
+{{ with .Description }} {{ $.Scratch.Set "subtitle" . }} {{ end }}
+{{ with .ReadingTime }} {{ $.Scratch.Set "read_time" . }} {{ end }}
+
+
+<h4><a href="{{ .Scratch.Get "link" }}">{{ .Title }}</a></h4>
+    <h5>{{ $.Scratch.Get "pub_date" }}</h5>
+    <h5>{{ $.Scratch.Get "subtitle" }}</h5>
+    {{ range.Params.categories }}
+<a href="{{"/categories/"|relLangURL }}{{.|urlize}}">
+    <kbd class="item-cat"> {{ . }} </kbd>
+        </a>
+        {{ end }}
+    {{ range .Params.tags }}
+    <a href="{{"/tags/"|relLangURL }}{{.|urlize}}">
+        <kbd class="item-tag"> {{ . }} </kbd>
+            </a>
+            {{ end }}
+        
+        </div>
+            

--- a/layouts/partials/list-item.html
+++ b/layouts/partials/list-item.html
@@ -18,8 +18,17 @@
 
     <h4><a href="{{ .Scratch.Get "link" }}">{{ .Title }}</a></h4>
     <h5>{{ $.Scratch.Get "subtitle" }}</h5>
+
+    {{ range.Params.categories }}
+        <a href="{{"/categories/"|relLangURL }}{{.|urlize}}">
+        <kbd class="item-cat"> {{ . }} </kbd>
+    </a>
+    
+    {{ end }}
     {{ range .Params.tags }}
-    <a href="{{ $.Site.BaseURL }}tags/{{ . | urlize }}"><kbd class="item-tag">{{ . }}</kbd></a>
+    <a href="{{"/tags/"|relLangURL }}{{.|urlize}}">
+        <kbd class="item-tag"> {{ . }} </kbd>
+    </a>
     {{ end }}
 
 </div>

--- a/layouts/partials/list-item.html
+++ b/layouts/partials/list-item.html
@@ -23,6 +23,7 @@
     <h5>{{ $.Scratch.Get "subtitle" }}</h5>
 
     {{ range.Params.categories }}
+
         <a href="{{"/categories/"|relLangURL }}{{.|urlize}}">
         <kbd class="item-cat"> {{ . }} </kbd>
     </a>

--- a/layouts/partials/toggle.html
+++ b/layouts/partials/toggle.html
@@ -1,0 +1,9 @@
+<li id="night-mode-toggle">
+    <input type="checkbox" id = "button-status"
+        data-toggle="toggle"
+        data-size = "small"
+        data-on="<i class='fa fa-moon-o fa-lg'></i>"
+        data-off= "<i class='fa fa-sun-o fa-lg'></i>"
+        data-style="ios",
+        data-onstyle = "default">
+</li>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -127,6 +127,16 @@ img {
     -webkit-filter: invert(1) hue-rotate(180deg);
     filter: invert(1) hue-rotate(180deg)
 }
+/* "re-flip"" certain elements to keep colors */
+#bigbody.-nightmode img, video {
+    -webkit-filter: invert(1) hue-rotate(-180deg);
+    filter: invert(1) hue-rotate(-180deg)
+}
+#bigbody.-nightmode iframe {
+    -webkit-filter: invert(1) hue-rotate(-180deg);
+    filter: invert(1) hue-rotate(-180deg)
+}
+/* custom behavior for specfic element */
 #bigbody.-nightmode main a {
     color: var(--accent) !important;
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -33,7 +33,7 @@ main {
 }
 
 .intro > h2 {
-    font-size: 3vmin;
+    font-size: 4vh;
 }
 
 .intro > .profile {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -29,12 +29,10 @@ main {
 }
 
 .intro > h1 {
-    color: #212121;
     font-size: 12vh;
 }
 
 .intro > h2 {
-    color: #757575;
     font-size: 3vmin;
 }
 
@@ -49,12 +47,16 @@ main {
 a:link, a:visited {
     color: var(--accent);
 }
+a:link.-nightmode {
+    color = "ebe4d1"
+}
 
 a.icon:hover {
     text-decoration: none;
 }
 
 a:hover {
+    text-decoration: none;
     color: var(--accent) !important;
 }
 
@@ -74,8 +76,20 @@ a:hover {
     padding: 10px 0;
 }
 
+.item-cat {
+    background-color: #757575;
+    margin:1px;
+}
+
 .item-tag {
     background-color: var(--accent);
+    margin:1px;
+}
+
+.terms {
+    margin: 1px;
+    padding: 1px;
+    list-style-type: none;
 }
 
 /*navigation bar icons*/
@@ -86,15 +100,61 @@ a:hover {
 }
 
 /*coloured borders at top and bottom of the page*/
-
 .navbar.navbar-default {
     border-top: var(--border-width) solid var(--accent);
 }
 
+/* custome footer */
 footer {
+    background-color: #f8f8f8;
+    border-top: #e7e7e7 solid;
+    border-top-width: 1px;
+    color:"white";
     border-bottom: var(--border-width) solid var(--accent);
 }
 
 img {
     max-width: 100%;
+}
+
+/** Intvert colors
+ * Wonderful CSS filter trick by Leo Nikkilä
+ * @link https://lnikki.la/articles/night-mode-css-filter/
+ */
+#bigbody.-nightmode {
+    background: var(--accent)!important;
+    color: #333333 !important;
+    -webkit-filter: invert(1) hue-rotate(180deg);
+    filter: invert(1) hue-rotate(180deg)
+}
+#bigbody.-nightmode main a {
+    color: var(--accent) !important;
+}
+#bigbody.-nightmode .item-tag {
+    background-color: var(--accent) !important;
+    color: #f8f8f8 !important;
+}
+
+/* slider attributes match navbar elements */
+#night-mode-toggle {
+    display: inline-block !important;
+    padding-top:10px;
+    font-size: 125%;
+}
+/* built on-top of Custom Style .ios 
+   from: http://www.bootstraptoggle.com/ */
+.toggle.ios, .toggle-on.ios, .toggle-off.ios { border-radius: 20px}
+.toggle.ios .toggle-handle { border-radius: 20px;}
+.toggle.ios .toggle-group {transition: none;-webkit-transition: none;}
+
+.toggle-on {
+    background-color: #757575 !important;
+    color: #f5f5f5 !important;
+}
+.toggle-on:hover {
+    background-color: var(--accent) !important;
+}
+.toggle-off:hover {
+    background-color: var(--accent) !important;
+    color: #f8f8f8 !important;
 }

--- a/theme.toml
+++ b/theme.toml
@@ -1,10 +1,10 @@
-name = "Minimal2"
+name = "MinNight"
 license = "MIT"
 licenselink = "https://github.com/nathancday/minimal2/blob/master/LICENSE.md"
-description = "Personal blog theme powered by Hugo"
-homepage = "http://github.com/nathancday/minimal2"
-tags = ["blog", "minimal", "personal", "responsive"]
-features = ["responsive", "night-theme"]
+description = "A night-mode theme for Hugo built on Minimal"
+homepage = "http://github.com/nathancday/min_night"
+tags = ["minimal", "dark", "light", "link_tags", "bootstrap"]
+features = ["responsive", "night-mode", "dark-mode"]
 min_version = "0.24.1"
 
 [author]

--- a/theme.toml
+++ b/theme.toml
@@ -1,12 +1,12 @@
-name = "Minimal"
+name = "Minimal2"
 license = "MIT"
-licenselink = "https://github.com/calintat/minimal/blob/master/LICENSE.md"
+licenselink = "https://github.com/nathancday/minimal2/blob/master/LICENSE.md"
 description = "Personal blog theme powered by Hugo"
-homepage = "http://github.com/calintat/minimal/"
+homepage = "http://github.com/nathancday/minimal2"
 tags = ["blog", "minimal", "personal", "responsive"]
-features = ["responsive"]
+features = ["responsive", "night-theme"]
 min_version = "0.24.1"
 
 [author]
-  name = "Calin Tataru"
-  homepage = "https://calintat.github.io/"
+  name = "Nate Day"
+  homepage = "https://natedayta.com"

--- a/theme.toml
+++ b/theme.toml
@@ -1,7 +1,7 @@
 name = "MinNight"
 license = "MIT"
-licenselink = "https://github.com/nathancday/minimal2/blob/master/LICENSE.md"
-description = "A night-mode theme for Hugo built on Minimal"
+licenselink = "https://github.com/nathancday/min_night/blob/master/LICENSE.md"
+description = "A sleek dark-mode toggle-able Hugo theme"
 homepage = "http://github.com/nathancday/min_night"
 tags = ["minimal", "dark", "light", "link_tags", "bootstrap"]
 features = ["responsive", "night-mode", "dark-mode"]


### PR DESCRIPTION
I think we are ready to merge in my night-mode toggle. I changed the accent color (maroon) for a better dark mode demo and changed the text-highlight to match.

Minor other tweaks that I kept in there are:
- Separate templates for post/ and projects/
- A tags page

Let me know if you don't like either of those and I can rework.

I recommend squashing all of these commits into 1 when your merge this, I could also do this with interactive rebase but you are in an easier position. Everything has been rebased and it should be ready to fast-forward

Note: the user MUST delete the default Hugo archetypes/default.md and use the minimal/archetypes/ for this to work properly. Or else the JS and CSS rules for the toggle won't connect.

Cheers,
Nate

