### PR TITLE
min_night merge

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Calin Tataru
+Copyright (c) 2017 Nate Day
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Nate Day
+Copyright (c) 2017 Calin Tataru
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
-# Minimal
+# MinNight
 
-Personal blog theme powered by [Hugo](https://gohugo.io).
-A live demo is available [here](https://themes.gohugo.io/theme/minimal/).
+A sleek toggleable night-mode theme for [Hugo](https://gohugo.io). Built on top on the great [Minimal](https://github.com/calintat/minimal) theme. Keeps all of the great Minimal stuff, like custom accent color, Google Fonts, FontAwesome menu icons, and layers on:
+
+- A night-mode toggle, for eye easy reading
+- A tags/categories list page template from [Xmin](https://github.com/yihui/hugo-xmin)
+- Updated tag labels to hyperlinks
+- Different list templates for posts and projects
+
+A live demo is available [here](https://natedayta.com).
 
 ## Installation
 
@@ -10,7 +16,7 @@ You can install the theme either as a clone or submodule.
 I recommend the latter. From the root of your Hugo site, type the following:
 
 ```
-$ git submodule add https://github.com/calintat/minimal.git themes/minimal
+$ git submodule add https://github.com/nathancday/min_night themes/min_night
 $ git submodule init
 $ git submodule update
 ```
@@ -18,41 +24,44 @@ $ git submodule update
 Now you can get updates to Minimal in the future by updating the submodule:
 
 ```
-$ git submodule update --remote themes/minimal
+$ git submodule update --remote themes/min_night
+```
+
+I use this theme via the `R` pacakge `blogdown`, you can do the same in R.
+
+```
+library(blogdown)
+new_site(theme = "nathancday/min_night")
 ```
 
 ## Configuration
 
-After installation, take a look at the `exampleSite` folder inside `themes/minimal`.
+After installation, take a look at the `exampleSite` folder inside `themes/minimal2`.
 
 To get started, copy the `config.toml` file inside `exampleSite` to the root of your Hugo site:
 
 ```
-$ cp themes/minimal/exampleSite/config.toml .
+$ cp themes/min_night/exampleSite/config.toml .
 ```
 
-Now edit this file and add your own information. Note that some fields can be ommited.
-
-I recommend you use the theme's archetypes so now delete your site's `archetypes/default.md`.
+This file is the centerpiece for easy theme customizations. Some noteable features are described next.
 
 ## Features
 
-You can tweak the look of the theme to suit your needs in a number of ways:
+- The accent colour can be changed by using the `accent` field in `config.toml`. This is the color that will be used as the background of your site in dark-mode. Dark colors work best.
 
-- The accent colour can be changed by using the `accent` field in `config.toml`.
+- You can also change the background color of the main page by using `backgroundColor`. The navbar and footer are always light and dark in the their respective modes.
 
-- You can also change the background colour by using `backgroundColor`.
+- Add colored 5px borders at the top and bottom of pages by setting `showBorder` to `true`. Even if this is set to `false` the `accent` color will still be used for the main page background in dark-mode.
 
-- Add colored 5px borders at the top and bottom of pages by setting `showBorder` to `true`.
-
-For best results, I recommend you use a dark accent colour with a light background, for example:
-
+Example:
 ```toml
 [params]
     accent = "red"
     showBorder = true
-    backgroundColor = "white"
+    backgroundColor = "#f5f5f5"
 ```
+You can use either hex codes or color names ("red"), I reccomend using hex codes for more specific color assignments.
 
 ### Fonts
 
@@ -65,21 +74,17 @@ The theme uses [Google Fonts](https://fonts.google.com) to load its font. To cha
 
 ### Syntax highlighting
 
-The theme supports syntax highlighting thanks to [highlight.js](https://highlightjs.org).
+The theme supports syntax highlighting thanks to [highlight.js](https://highlightjs.org). You can change the color scheme via the `highlightStyle` param. Checkout out the options [here](https://highlightjs.org/static/demo/), make sure your main languages render well. For best results with dark-mode, I reccommend choosing a light background style that matches your `accent` color. You control the languages that are highlighted with the `highlightLanguages` param.
 
-It's disabled by default, so you have to enable it by setting `highlight` to `true` in your config.
-
-You can change the style used for the highlighting by using the `highlightStyle` field.
-
-Only the "common" languages will be loaded by default. To load more, use `highlightLanguages`.
-
-A list of all the available styles and languages can be found [here](https://highlightjs.org/static/demo/).
-
-Please note the style and languages should be written in hyphen-separated lowercase, for example:
+The style and languages should be written in hyphen-separated lowercase, for example:
 
 ```toml
 [params]
     highlight = true
     highlightStyle = "solarized-dark"
-    highlightLanguages = ["go", "haskell", "kotlin", "scala", "swift"]
+    highlightLanguages = ["r", "go"]
 ```
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,13 +1,8 @@
-# MinNight
+# Minimal
 
-A sleek toggleable night-mode theme for [Hugo](https://gohugo.io). Built on top on the great [Minimal](https://github.com/calintat/minimal) theme. Keeps all of the great Minimal stuff, like custom accent color, Google Fonts, FontAwesome menu icons, and layers on:
-
-- A night-mode toggle, for eye easy reading
-- A tags/categories list page template from [Xmin](https://github.com/yihui/hugo-xmin)
-- Updated tag labels to hyperlinks
-- Different list templates for posts and projects
-
-A live demo is available [here](https://natedayta.com).
+-Personal blog theme with night-mode, powered by [Hugo](https://gohugo.io).
+-Quickly customize colors, icons and fonts.
+-A live demo is available [here](https://themes.gohugo.io/theme/minimal/).
 
 ## Installation
 
@@ -16,7 +11,7 @@ You can install the theme either as a clone or submodule.
 I recommend the latter. From the root of your Hugo site, type the following:
 
 ```
-$ git submodule add https://github.com/nathancday/min_night themes/min_night
+$ git submodule add https://github.com/calintat/minimal.git themes/minimal
 $ git submodule init
 $ git submodule update
 ```
@@ -24,27 +19,22 @@ $ git submodule update
 Now you can get updates to Minimal in the future by updating the submodule:
 
 ```
-$ git submodule update --remote themes/min_night
-```
-
-I use this theme via the `R` pacakge `blogdown`, you can do the same in R.
-
-```
-library(blogdown)
-new_site(theme = "nathancday/min_night")
+$ git submodule update --remote themes/minimal
 ```
 
 ## Configuration
 
-After installation, take a look at the `exampleSite` folder inside `themes/minimal2`.
+After installation, take a look at the `exampleSite` folder inside `themes/minimal`.
 
 To get started, copy the `config.toml` file inside `exampleSite` to the root of your Hugo site:
 
 ```
-$ cp themes/min_night/exampleSite/config.toml .
+$ cp themes/minimal/exampleSite/config.toml .
 ```
 
 This file is the centerpiece for easy theme customizations. Some noteable features are described next.
+
+Note: Please delete your site's `archetypes/default.md` inorder for the theme to function properly.
 
 ## Features
 
@@ -57,7 +47,7 @@ This file is the centerpiece for easy theme customizations. Some noteable featur
 Example:
 ```toml
 [params]
-    accent = "red"
+    accent = "maroon"
     showBorder = true
     backgroundColor = "#f5f5f5"
 ```
@@ -82,7 +72,7 @@ The style and languages should be written in hyphen-separated lowercase, for exa
 [params]
     highlight = true
     highlightStyle = "solarized-dark"
-    highlightLanguages = ["r", "go"]
+    highlightLanguages = ["go", "haskell", "kotlin", "scala", "swift"]
 ```
 
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,4 +1,4 @@
-baseURL = "http://example.com/"
+baseURL = "/"
 languageCode = "en-us"
 title = "Minimal"
 theme = "minimal"
@@ -7,16 +7,17 @@ googleAnalytics = ""
 
 [params]
     author = "Calin Tataru"
-    description = "Personal blog theme powered by Hugo"
+    description = "Personal blog theme with night-mode powered by Hugo"
     githubUsername = "#"
-    accent = "red"
+    accent = "maroon"
     showBorder = true
-    backgroundColor = "white"
+    backgroundColor = "#f5f5f5"
     font = "Raleway" # should match the name on Google Fonts!
     highlight = true
-    highlightStyle = "solarized-dark"
-    highlightLanguages = ["go", "haskell", "kotlin", "scala", "swift"]
+    highlightStyle = "atelier-heath-light" # make this complement accent color!
+    highlightLanguages = ["go", "haskell", "kotlin", "scala", "swift", "r"]
 
+# adjust these as you see fit
 [[menu.main]]
     url = "/"
     name = "Home"
@@ -31,6 +32,11 @@ googleAnalytics = ""
     url = "/project/"
     name = "Projects"
     weight = 3
+    
+[[menu.main]]
+    url = "/tags/"
+    name = "Tags"
+    weight = 4
 
 # Social icons to be shown on the right-hand side of the navigation bar
 # The "name" field should match the name of the icon to be used

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,13 +1,19 @@
 {{ partial "header" . }}
 
 <main>
-
     <h2>{{ .Title }}</h2>
 
-    {{ range (.Paginator 5).Pages }} {{ partial "list-item" . }} {{ end }}
-
+    {{ range (.Paginator 10).Pages }}
+        {{ if eq "Posts" $.Title }}
+           {{partial "list-item-post.html" .}}
+        {{else}}
+            {{ partial "list-item-project" . }}
+        {{end}}
+    {{end}}
+    
 </main>
 
 {{ partial "paginator" . }}
+
 
 {{ partial "footer" . }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,13 +1,23 @@
 {{ partial "header" . }}
 
 <main>
-
-    <h2>{{ .Title }}</h2>
-
-    {{ range (.Paginator 5).Pages }} {{ partial "list-item" . }} {{ end }}
+    
+    <div>
+      <h2>{{ .Title }}</h2>
+    
+      <ul class="terms">
+          {{ range $key, $value := .Data.Terms }}
+          <li>
+            <a href='{{ (print "/" $.Data.Plural "/" $key) | relURL }}'>
+              {{ $key }}
+            </a>
+            ({{ len $value }})
+          </li>
+          {{ end }}
+        </ul>
+    </div>
 
 </main>
-
-{{ partial "paginator" . }}
+  
 
 {{ partial "footer" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ partial "header" . }}
 
-<main>
+<main class = "content-box">
 
     <div class="intro">
 

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -20,6 +20,7 @@
 
 <!-- google fonts -->
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family={{ .Site.Params.font }}">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=VT323">
 
 <!-- highlight.js -->
 {{ if .Site.Params.highlight | default false }} <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/{{ .Site.Params.highlightStyle | default "default" }}.min.css"> {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,8 +1,17 @@
         <footer>
-
-            <p class="copyright text-muted">{{ .Site.Params.copyright | default "&copy; All rights reserved. Powered by [Hugo](https://gohugo.io) and [Minimal](https://github.com/calintat/minimal)" | markdownify }}</p>
-
+            <div style = "padding:15px;">
+                <p class="copyright text-muted">{{ .Site.Params.copyright | default "&copy; All rights reserved. Powered by [Hugo](https://gohugo.io) and [Minimal](https://github.com/calintat/minimal)" | markdownify }}
+                </p>
+            </div>
         </footer>
+        <!-- Global Site Tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments)};
+          gtag('js', new Date());
+          gtag('config', '{{ .Site.GoogleAnalytics }}');
+        </script>
        
     </body>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -25,6 +25,16 @@
           gtag('config', '{{ .Site.GoogleAnalytics }}');
         </script>
         {{ end }}
+        
+    <!--- Favicons from  --->
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png">
+    <link rel="manifest" href="/images/favicon/manifest.json">
+    <link rel="mask-icon" href="/images/favicon/safari-pinned-tab.svg" color="#006264">
+    <link rel="shortcut icon" href="/images/favicon/favicon.ico">
+    <meta name="msapplication-config" content="/images/favicon/browserconfig.xml">
+    <meta name="theme-color" content="#ffffff">
     </head>
 
     {{ if .Site.Params.MathJax | default true }}
@@ -34,7 +44,7 @@
     </script>
     {{ end }}
 
-    <body>
+    <body id = "bigbody">
         {{ partial "body-open" . }}
         <nav class="navbar navbar-default navbar-fixed-top">
 
@@ -67,6 +77,8 @@
                             {{ range sort .Site.Menus.icon }}
                                 <li class="navbar-icon"><a href="{{ .URL }}"><i class="fa fa-{{ .Name }}"></i></a></li>
                             {{ end }}
+                            
+                            {{ partial "toggle"}}
                         </ul>
                     {{ end }}
 

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -18,5 +18,38 @@
 <!-- bootstrap -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
+<!-- boostrap toggle tool -->
+<link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">
+<script src="https://gitcdn.github.io/bootstrap-toggle/2.2.2/js/bootstrap-toggle.min.js"></script>
+
 <!-- dismiss expanded navigation bar with click -->
 <script>$(document).on('click', function() { $('.collapse').collapse('hide'); })</script>
+
+<!-- nightmode css changes -->
+<script>
+$(document).ready(function(){
+    
+  var input = $('#night-mode-toggle');
+  var container = $('#bigbody');
+  var stat = $('#button-status');
+  
+  container.toggleClass(localStorage.toggled);
+  stat.bootstrapToggle(localStorage.button).change();
+  
+  
+  input.on('click', function() {
+      if (localStorage.toggled != "-nightmode" ) {
+          container.toggleClass("-nightmode", true );
+          localStorage.toggled = "-nightmode";
+          localStorage.button = "on";
+       } else {
+          container.toggleClass("-nightmode", false );
+          localStorage.toggled = "";
+          localStorage.button = "off"
+       }
+  })
+});
+</script>
+
+
+

--- a/layouts/partials/list-item-post.html
+++ b/layouts/partials/list-item-post.html
@@ -21,9 +21,7 @@
     <h4><a href="{{ .Scratch.Get "link" }}">{{ .Title }}</a></h4>
     <h5>{{ $.Scratch.Get "pub_date" }} - {{ $.Scratch.Get "read_time" }} minutes</h5>
     <h5>{{ $.Scratch.Get "subtitle" }}</h5>
-
     {{ range.Params.categories }}
-
         <a href="{{"/categories/"|relLangURL }}{{.|urlize}}">
         <kbd class="item-cat"> {{ . }} </kbd>
     </a>

--- a/layouts/partials/list-item-project.html
+++ b/layouts/partials/list-item-project.html
@@ -1,0 +1,36 @@
+<div class="item">
+    
+{{ $.Scratch.Set "link" .RelPermalink }}
+{{ with .Params.repo }}
+{{ $repoHost := default "github" $.Params.repoHost }}
+{{ if eq "github" $repoHost }}
+{{ printf "https://github.com/%s/%s/" $.Site.Params.githubUsername . | $.Scratch.Set "link" }}
+{{ else if eq "gitlab" $repoHost }}
+{{ printf "https://gitlab.com/%s/%s/" $.Site.Params.gitlabUsername . | $.Scratch.Set "link" }}
+{{ else if eq "bitbucket" $repoHost }}
+{{ printf "https://bitbucket.org/%s/%s/" $.Site.Params.bitbucketUsername . | $.Scratch.Set "link" }}
+{{ end }}
+{{ end }}
+{{ with .Params.link }} {{ $.Scratch.Set "link" . }} {{ end }}
+
+{{ .Date.Format (.Site.Params.dateFormat | default "January 2, 2006") | $.Scratch.Set "pub_date" }}
+{{ with .Description }} {{ $.Scratch.Set "subtitle" . }} {{ end }}
+{{ with .ReadingTime }} {{ $.Scratch.Set "read_time" . }} {{ end }}
+
+
+<h4><a href="{{ .Scratch.Get "link" }}">{{ .Title }}</a></h4>
+    <h5>{{ $.Scratch.Get "pub_date" }}</h5>
+    <h5>{{ $.Scratch.Get "subtitle" }}</h5>
+    {{ range.Params.categories }}
+<a href="{{"/categories/"|relLangURL }}{{.|urlize}}">
+    <kbd class="item-cat"> {{ . }} </kbd>
+        </a>
+        {{ end }}
+    {{ range .Params.tags }}
+    <a href="{{"/tags/"|relLangURL }}{{.|urlize}}">
+        <kbd class="item-tag"> {{ . }} </kbd>
+            </a>
+            {{ end }}
+        
+        </div>
+            

--- a/layouts/partials/toggle.html
+++ b/layouts/partials/toggle.html
@@ -1,0 +1,9 @@
+<li id="night-mode-toggle">
+    <input type="checkbox" id = "button-status"
+        data-toggle="toggle"
+        data-size = "small"
+        data-on="<i class='fa fa-moon-o fa-lg'></i>"
+        data-off= "<i class='fa fa-sun-o fa-lg'></i>"
+        data-style="ios",
+        data-onstyle = "default">
+</li>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -29,13 +29,11 @@ main {
 }
 
 .intro > h1 {
-    color: #212121;
     font-size: 12vh;
 }
 
 .intro > h2 {
-    color: #757575;
-    font-size: 3vmin;
+    font-size: 4vh;
 }
 
 .intro > .profile {
@@ -49,12 +47,16 @@ main {
 a:link, a:visited {
     color: var(--accent);
 }
+a:link.-nightmode {
+    color = "ebe4d1"
+}
 
 a.icon:hover {
     text-decoration: none;
 }
 
 a:hover {
+    text-decoration: none;
     color: var(--accent) !important;
 }
 
@@ -74,8 +76,20 @@ a:hover {
     padding: 10px 0;
 }
 
+.item-cat {
+    background-color: #757575;
+    margin:1px;
+}
+
 .item-tag {
     background-color: var(--accent);
+    margin:1px;
+}
+
+.terms {
+    margin: 1px;
+    padding: 1px;
+    list-style-type: none;
 }
 
 /*navigation bar icons*/
@@ -86,15 +100,71 @@ a:hover {
 }
 
 /*coloured borders at top and bottom of the page*/
-
 .navbar.navbar-default {
     border-top: var(--border-width) solid var(--accent);
 }
 
+/* custome footer */
 footer {
+    background-color: #f8f8f8;
+    border-top: #e7e7e7 solid;
+    border-top-width: 1px;
+    color:"white";
     border-bottom: var(--border-width) solid var(--accent);
 }
 
 img {
     max-width: 100%;
+}
+
+/** Intvert colors
+ * Wonderful CSS filter trick by Leo Nikkilä
+ * @link https://lnikki.la/articles/night-mode-css-filter/
+ */
+#bigbody.-nightmode {
+    background: var(--accent)!important;
+    color: #333333 !important;
+    -webkit-filter: invert(1) hue-rotate(180deg);
+    filter: invert(1) hue-rotate(180deg)
+}
+/* "re-flip"" certain elements to keep colors */
+#bigbody.-nightmode img, video {
+    -webkit-filter: invert(1) hue-rotate(-180deg);
+    filter: invert(1) hue-rotate(-180deg)
+}
+#bigbody.-nightmode iframe {
+    -webkit-filter: invert(1) hue-rotate(-180deg);
+    filter: invert(1) hue-rotate(-180deg)
+}
+/* custom behavior for specfic element */
+#bigbody.-nightmode main a {
+    color: var(--accent) !important;
+}
+#bigbody.-nightmode .item-tag {
+    background-color: var(--accent) !important;
+    color: #f8f8f8 !important;
+}
+
+/* slider attributes match navbar elements */
+#night-mode-toggle {
+    display: inline-block !important;
+    padding-top:10px;
+    font-size: 125%;
+}
+/* built on-top of Custom Style .ios 
+   from: http://www.bootstraptoggle.com/ */
+.toggle.ios, .toggle-on.ios, .toggle-off.ios { border-radius: 20px}
+.toggle.ios .toggle-handle { border-radius: 20px;}
+.toggle.ios .toggle-group {transition: none;-webkit-transition: none;}
+
+.toggle-on {
+    background-color: #757575 !important;
+    color: #f5f5f5 !important;
+}
+.toggle-on:hover {
+    background-color: var(--accent) !important;
+}
+.toggle-off:hover {
+    background-color: var(--accent) !important;
+    color: #f8f8f8 !important;
 }

--- a/theme.toml
+++ b/theme.toml
@@ -1,12 +1,12 @@
-name = "Minimal"
+name = "MinNight"
 license = "MIT"
-licenselink = "https://github.com/calintat/minimal/blob/master/LICENSE.md"
-description = "Personal blog theme powered by Hugo"
-homepage = "http://github.com/calintat/minimal/"
-tags = ["blog", "minimal", "personal", "responsive"]
-features = ["responsive"]
+licenselink = "https://github.com/nathancday/min_night/blob/master/LICENSE.md"
+description = "A sleek dark-mode toggle-able Hugo theme"
+homepage = "http://github.com/nathancday/min_night"
+tags = ["minimal", "dark", "light", "link_tags", "bootstrap"]
+features = ["responsive", "night-mode", "dark-mode"]
 min_version = "0.24.1"
 
 [author]
-  name = "Calin Tataru"
-  homepage = "https://calintat.github.io/"
+  name = "Nate Day"
+  homepage = "https://natedayta.com"

--- a/theme.toml
+++ b/theme.toml
@@ -1,12 +1,12 @@
-name = "MinNight"
+name = "Minimal"
 license = "MIT"
-licenselink = "https://github.com/nathancday/min_night/blob/master/LICENSE.md"
-description = "A sleek dark-mode toggle-able Hugo theme"
-homepage = "http://github.com/nathancday/min_night"
-tags = ["minimal", "dark", "light", "link_tags", "bootstrap"]
+licenselink = "https://github.com/calintat/minimal/blob/master/LICENSE.md"
+description = "Personal blog theme powered by Hugo"
+homepage = "http://github.com/calintat/minimal/"
+tags = ["blog", "minimal", "personal", "responsive"]
 features = ["responsive", "night-mode", "dark-mode"]
 min_version = "0.24.1"
 
 [author]
-  name = "Nate Day"
-  homepage = "https://natedayta.com"
+  name = "Calin Tataru"
+  homepage = "https://calintat.github.io/"


### PR DESCRIPTION
I smashed it down to one commit and I think we are ready to merge in the night-mode toggle. I changed the accent color (maroon) for a better dark mode demo and changed the text-highlight to match.

Minor other tweaks that I kept in there are:

- Separate templates for post/ and projects/ 
- A tags/categories template page, simple list ( minimalist :) )

Let me know if you don't like either of those and I can rework.

Note: the user MUST delete the default Hugo archetypes/default.md and use the minimal/archetypes/ for this to work properly. Or else the JS and CSS rules for the toggle won't connect.

Cheers,
Nate