### PR TITLE
Switched Font Awesome with Fork Awesom

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -34,7 +34,7 @@ googleAnalytics = ""
 
 # Social icons to be shown on the right-hand side of the navigation bar
 # The "name" field should match the name of the icon to be used
-# The list of available icons can be found at http://fontawesome.io/icons/
+# The list of available icons can be found at https://forkawesome.github.io/Fork-Awesome/icons/
 
 [[menu.icon]]
     url = "mailto:me@example.com"

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -27,5 +27,5 @@
 <!-- bootstrap -->
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 
-<!-- font awesome -->
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+<!-- fork awesome -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fork-awesome@1.1.0/css/fork-awesome.min.css" integrity="sha256-sX8HLspqYoXVPetzJRE4wPhIhDBu2NB0kYpufzkQSms=" crossorigin="anonymous">


### PR DESCRIPTION
Font Awesome's open source support seems to have died, so another group has taken the 4.7 fonts and added to them. Using Fork Awesome gives us access to new icons such as ones for Mastodon and Keybase.

NOTE: I haven't been able to do a full test to make sure this doesn't introduce breaking changes, outside of making sure the URL for the icons is valid since I don't know what's the best way to test themes.