### PR TITLE
display index page content

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,6 +10,11 @@
 
         <h2>{{ markdownify .Site.Params.Description }}</h2>
 
+        {{ with .Content }}
+            <div class="homepage-content text-justify">
+                {{ . }}
+            </div>
+        {{ end }}
     </div>
 
 </main>


### PR DESCRIPTION
This allows content from `content/_index.md` (if any) to be displayed on the homepage, as per https://gohugo.io/templates/homepage/ .