### PR TITLE
Fix hugo 0.55 deprecation warnings without breaking RSS

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,10 +8,10 @@
         {{ if .Site.Params.favicon }}
         <link rel="icon" href="{{ .Site.Params.favicon | absURL }}">
         {{ end }}
-        {{ partial "css" . }} {{ partial "js" . }} {{ .Hugo.Generator }}
-        {{ if .RSSLink }}
-        <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-        <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+        {{ partial "css" . }} {{ partial "js" . }} {{ hugo.Generator }}
+        {{ with .OutputFormats.Get "RSS" }}
+        <link href="{{ .RelPermalink }}" rel="alternate" type="{{ .MediaType.Type }}" title="{{ $.Site.Title }}" />
+        <link href="{{ .RelPermalink }}" rel="feed" type="{{ .MediaType.Type }}" title="{{ $.Site.Title }}" />
         {{ end }}
 
         {{ if .Site.GoogleAnalytics }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,8 +8,11 @@
         {{ if .Site.Params.favicon }}
         <link rel="icon" href="{{ .Site.Params.favicon | absURL }}">
         {{ end }}
-        {{ partial "css" . }} {{ partial "js" . }} {{ hugo.Generator }}
-        {{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}.
+        {{ partial "css" . }} {{ partial "js" . }} {{ .Hugo.Generator }}
+        {{ if .RSSLink }}
+        <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+        <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+        {{ end }}
 
         {{ if .Site.GoogleAnalytics }}
         <!-- Global Site Tag (gtag.js) - Google Analytics -->


### PR DESCRIPTION
In commit 83eed85 the deprecation warnings given by hugo 0.55 are dealt with, but the previous `<link>` tags for RSS feeds have been removed, with the link to the RSS feed being placed into the `<head>` tag itself as raw text. In addition to breaking RSS feeds, FF at least will display that path prominently in the actual pages.

This PR should deal with the deprecation without changing the output of the original template.