### PR TITLE
Move mathjax include to head from document

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -25,14 +25,14 @@
           gtag('config', '{{ .Site.GoogleAnalytics }}');
         </script>
         {{ end }}
-    </head>
 
-    {{ if .Site.Params.MathJax | default true }}
-    <!-- adds MathJax support -->
-    <script type="text/javascript" async
-      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
-    </script>
-    {{ end }}
+        {{ if .Site.Params.MathJax | default true }}
+        <!-- adds MathJax support -->
+        <script type="text/javascript" async
+          src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        </script>
+        {{ end }}
+    </head>
 
     <body>
         {{ partial "body-open" . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -29,7 +29,7 @@
         {{ if .Site.Params.MathJax | default true }}
         <!-- adds MathJax support -->
         <script type="text/javascript" async
-          src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+          src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
         </script>
         {{ end }}
     </head>


### PR DESCRIPTION
The MathJax `<script>` tag belongs to either `<head>` or `<body>´, but not into the top-level `<document>`.

Since I touched that part of the template, I also updated MathJax to its newest version (2.7.5).