### PR TITLE
upgrade jQuery to latest (3.4.1) - fixes security vuln

### DIFF
--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -13,7 +13,7 @@
 {{ range .Site.Params.js }} <script src="{{ . | absURL }}"></script> {{ end }}
 
 <!-- jquery -->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 
 <!-- bootstrap -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>


### PR DESCRIPTION
fixes [security vulnerabilities](https://snyk.io/vuln/npm:jquery?lh=3.2.1&utm_source=lighthouse) with jQuery 3.2.1 surfaced via Lighthouse.

Warning: untested! Not sure what all jQuery is used for in this theme, if anything.