### PR TITLE
Update Navbar to handle Hugo Children

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -47,7 +47,19 @@
                     {{ if .Site.Menus.main }}
                         <ul class="nav navbar-nav">
                             {{ range sort .Site.Menus.main }}
+                            {{ if .HasChildren }}
+                                <li class="nav-item dropdown">
+                                    <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">{{ .Name }}<span class="caret"></span></a>
+                                    <div class ="dropdown-menu">
+                                        {{ range .Children }}
+                                        <a href="{{ .URL }}">{{ .Name }}</a>
+                                        {{ end }}
+                                    </div>
+                                </li>
+
+                            {{ else }}
                                 <li><a href="{{ .URL }}">{{ .Name }}</a></li>
+                            {{ end }}
                             {{ end }}
                         </ul>
                     {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -50,11 +50,11 @@
                             {{ if .HasChildren }}
                                 <li class="nav-item dropdown">
                                     <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">{{ .Name }}<span class="caret"></span></a>
-                                    <div class ="dropdown-menu">
+                                    <ul class ="dropdown-menu">
                                         {{ range .Children }}
-                                        <a href="{{ .URL }}">{{ .Name }}</a>
+                                        <li><a href="{{ .URL }}">{{ .Name }}</a></li>
                                         {{ end }}
-                                    </div>
+                                    </ul>
                                 </li>
 
                             {{ else }}


### PR DESCRIPTION
This enables the header's Navbar to take advantage of the Hugo `config.*` files' `menu.menu` child/parent relations. I added a simple static carat for the dropdowns as well since this is using bootstrap 3. As I understand, bootstrap 4 adds the carat automatically, not really sure though.

The appearance of the dropdown menu isn't great, but I don't know CSS really, so I'm not sure how to clean this up. Feel free to make suggestions or edit yourself if you want.

This may fall outside of the scope of what this repo's vision is for minimal, but I wanted to propose it anyways so it ha the option to use more Hugo features.