### PR TITLE
Added text alignment param

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -13,6 +13,7 @@ googleAnalytics = ""
     showBorder = true
     backgroundColor = "white"
     font = "Raleway" # should match the name on Google Fonts!
+    contentTextAlign = "center"
     highlight = true
     highlightStyle = "default"
     highlightLanguages = ["go", "haskell", "kotlin", "scala", "swift"]

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -22,7 +22,7 @@
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family={{ .Site.Params.font }}">
 
 <!-- highlight.js -->
-{{ if .Site.Params.highlight | default false }} <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/{{ .Site.Params.highlightStyle | default "default" }}.min.css"> {{ end }}
+{{ if .Site.Params.highlight | default false }} <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.3.1/styles/{{ .Site.Params.highlightStyle | default "default" }}.min.css"> {{ end }}
 
 <!-- bootstrap -->
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -8,6 +8,7 @@
     :root {
         --accent: {{ .Site.Params.accent | default "#2196F3" }};
         --border-width: {{ if .Site.Params.showBorder | default false }} 5px {{ else }} 0 {{ end }};
+        --content-align: {{ .Site.Params.contentTextAlign | default "center" }};
     }
 
 </style>

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -1,8 +1,8 @@
 <!-- highlight.js -->
 {{ if .Site.Params.highlight | default false }}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.3.1/highlight.min.js"></script>
     {{ range .Site.Params.highlightLanguages }}
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/{{ . }}.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.3.1/languages/{{ . }}.min.js"></script>
     {{ end }}
     <script>hljs.initHighlightingOnLoad();</script>
 {{ end }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -40,6 +40,7 @@ img {
 
 .content {
     padding-top: 20px;
+    text-align: var(--content-align);
 }
 
 /* Profile picture */


### PR DESCRIPTION
I've added a simple left/center/right text alignment option for the user by adding a _contentTextAlign_ param.  This effects the text for .content styles, which is basically for posts.  Navigation arrows, titles, and the homepage are not affected by this.

For an example see here: [https://www.scenic-shop.com/mark6/posts/2020/2020-10-07-autolisp-layer-snippets/](https://www.scenic-shop.com/mark6/posts/2020/2020-10-07-autolisp-layer-snippets/)