### PR TITLE
.Site.GoogleAnalytic update

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,16 +14,6 @@
             <link href="{{ .RelPermalink }}" rel="feed" type="{{ .MediaType.Type }}" title="{{ $.Site.Title }}" />
         {{ end }}
 
-        {{ if .Site.GoogleAnalytics }}
-            <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"></script>
-            <script>
-              window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments)};
-              gtag('js', new Date());
-              gtag('config', '{{ .Site.GoogleAnalytics }}');
-            </script>
-        {{ end }}
-
         {{ if .Site.Params.MathJax | default true }}
             <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
         {{ end }}


### PR DESCRIPTION
The HUGO framework has moved away from the .Site.GoogleAnalytic this theme is still using, this checking removes it.